### PR TITLE
Replace full printed invoice comparison with containsString() assertion

### DIFF
--- a/src/test/java/pl/edu/agh/mwo/invoice/PrintInvoiceTest.java
+++ b/src/test/java/pl/edu/agh/mwo/invoice/PrintInvoiceTest.java
@@ -1,6 +1,7 @@
 package pl.edu.agh.mwo.invoice;
 
 import junit.framework.TestCase;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -38,16 +39,12 @@ public class PrintInvoiceTest extends TestCase {
         Product product = new FuelCanister("Diesel",new BigDecimal(4));
         invoice.addProduct(product,1);
         printInvoice(invoice);
-        Assert.assertEquals(
-                "Invoice number: 1\r\n"+
-                "Product: Diesel, Unit price: 4, " +
-                "Quantity: 1 || Netto value: 4 || VAT 23.00% || " +
-                "Excise: 5.56 || Gross value: 10.48\r\n"+
-                        "Number of positions: 1\r\n"+
-                "Net total: 4 || Tax total: 6.48 || Gross total: 10.48".trim(),
-                outputStreamCaptor.toString()
-                        .trim());
-
+        String printedInvoice = outputStreamCaptor.toString().trim();
+        Assert.assertThat(printedInvoice, Matchers.containsString("Invoice number: 1"));
+        Assert.assertThat(printedInvoice, Matchers.containsString("Product: Diesel, Unit price: 4,"));
+        Assert.assertThat(printedInvoice, Matchers.containsString("Quantity: 1 || Netto value: 4 || VAT 23.00% || "));
+        Assert.assertThat(printedInvoice, Matchers.containsString("Number of positions: 1"));
+        Assert.assertThat(printedInvoice, Matchers.containsString("Net total: 4 || Tax total: 6.48 || Gross total: 10.48"));
     }
     @Test
     public void testPrintTwoLinesOfProduct(){


### PR DESCRIPTION
Cześć,

problem, który napotkałaś to inna reprezentacja znaków końca linii w Windowsie (`\r\n`) i w Linuxie (`\n`). W Twoich testach napisałaś, że oczekujesz, że wydrukowana faktura będzie zawierać windowsowe znaki końca linii, a w ciągłej integracji końce linii są inne, o czym mówi ci asercja w teście. Jeszcze lepiej to było widać u mnie, gdy pobrałem kod do IntelliJ na linuxie:

![image](https://user-images.githubusercontent.com/3918865/229462065-66e1daf0-dec4-4f05-972a-9b1587318036.png)

Proponuję nie fixować się w teście na to, że "wydrukowana faktura będzie wyglądać tak", ale zamiast tego napisać "wydrykowana faktura zawiera to", "wydrukowana faktura zawiera tamto". 

Przepisałem jeden z Twoich testów za pomocą matchera [`containsString`](https://hamcrest.org/JavaHamcrest/javadoc/2.1/org/hamcrest/core/StringContains.html#containsString-java.lang.String-). Sprawdzam dzięki niemu kolejne oczekiwane linie w wydruku, ale nie wymagam konkretnych znaków końca linii. Można by z tego zrobić nawet osobne testy! Jeśli wtedy zabraknie jednego z elementów - czerwony będzie tylko test który odpowiadał za jego sprawdzenie i od razu będzie wiadomo co nie działa.

Powodzenia!